### PR TITLE
HTTP bearer auth

### DIFF
--- a/client/app/controller/login-menu-controller.js
+++ b/client/app/controller/login-menu-controller.js
@@ -1,5 +1,5 @@
-angular.module('pmsiplan').controller('LoginMenuController', ['$scope', '$location', 'AuthenticateJS',
-    function ($scope, $location, AuthenticateJS) {
+angular.module('pmsiplan').controller('LoginMenuController', ['$scope', '$location', 'AuthenticateJS', '$modal',
+    function ($scope, $location, AuthenticateJS, $modal) {
         var reset = function () {
             $scope.loggedin = AuthenticateJS.isLoggedIn();
             $scope.user = AuthenticateJS.getUser();
@@ -12,6 +12,24 @@ angular.module('pmsiplan').controller('LoginMenuController', ['$scope', '$locati
         $scope.logout = function () {
             AuthenticateJS.logout().then(function () {
                 $location.url('/login');
+            });
+        };
+
+        $scope.profile = function () {
+            $modal.open({
+                templateUrl: 'partials/profile-modal.html',
+                controller: function ($scope, $modalInstance, user) {
+                    $scope.user = user;
+
+                    $scope.ok = function () {
+                        $modalInstance.dismiss('ok');
+                    };
+                },
+                resolve: {
+                    user: function () {
+                        return $scope.user.data;
+                    }
+                }
             });
         };
 

--- a/client/app/less/main.less
+++ b/client/app/less/main.less
@@ -149,4 +149,8 @@ ul.pagination li.disabled a {
 
 .form-control, input.form-control, select.form-control {
     width: 100%;
+
+    &.disabled, &[disabled] {
+        cursor: auto;
+    }
 }

--- a/client/app/partials/login-menu.html
+++ b/client/app/partials/login-menu.html
@@ -5,6 +5,7 @@
         </a>
         <ul class="dropdown-menu user pull-right">
             <li>
+                <a class="pointer" data-ng-click="profile();">Profile</a>
                 <a class="pointer" data-ng-click="logout();">Logout</a>
             </li>
         </ul>

--- a/client/app/partials/profile-modal.html
+++ b/client/app/partials/profile-modal.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+    <h3 class="modal-title">Profile: {{ user.name }}</h3>
+</div>
+
+<div class="modal-body">
+    <form>
+        <div class="form-group">
+            <label for="token">Token</label>
+            <div class="form-widget">
+                <input type="text" class="form-control" id="token" data-ng-model="user.token" data-ng-keypress="return false" disabled>
+            </div>
+        </div>
+    </form>
+</div>
+
+<div class="modal-footer">
+    <button class="btn btn-warning" ng-click="ok()">Cancel</button>
+</div>

--- a/server/config/resources.js
+++ b/server/config/resources.js
@@ -3,7 +3,8 @@ module.exports = {
         type: 'document',
         schema: {
             attributes: {
-                name: String
+                name: String,
+                token: String
             }
         },
         user: true

--- a/server/package.json
+++ b/server/package.json
@@ -6,6 +6,7 @@
         "bedoon": "~2.0.0",
         "express": "~3.4.0",
         "passport": "~0.2.0",
+        "passport-http-bearer": "^1.0.1",
         "passport-ldapauth": "~0.0.1"
     }
 }


### PR DESCRIPTION
This allows user to have a token and query the API using:

* `Authorization` http-header with the `Bearer` strategy (for example: `Authorization: Bearer ac27d5cdb5f8cb327cf4df57`)
* the `access_token` query parameter (for example: `GET /api/auth/loggedin?access_token=ac27d5cdb5f8cb327cf4df57`)